### PR TITLE
Copyright year bump

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Jesus-QC
+Copyright (c) 2021-2022 Jesus-QC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
It's almost 2023 and the copyright year is still not bumped :)

And the splash/startup screen copyright year is not consistent with the LICENSE file.